### PR TITLE
Add config option to be able to disable single match redirects

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,3 +3,4 @@ Intelligent404:
     - ErrorPage
     - RedirectorPage
     - VirtualPage
+  redirect_on_single_match: true

--- a/code/Intelligent404.php
+++ b/code/Intelligent404.php
@@ -66,9 +66,11 @@ class Intelligent404 extends Extension
                 $ExactCount = $ExactMatches->Count();
                 $PossibleCount = $PossibleMatches->Count();
 
-                if ($ExactCount == 1) {
+                $redirectOnSingleMatch = Config::inst()->get('Intelligent404', 'redirect_on_single_match');
+
+                if ($ExactCount == 1 && $redirectOnSingleMatch) {
                     return $this->RedirectToPage($ExactMatches->First()->Link());
-                } elseif ($ExactCount == 0 && $PossibleCount == 1) {
+                } elseif ($ExactCount == 0 && $PossibleCount == 1 && $redirectOnSingleMatch) {
                     return $this->RedirectToPage($PossibleMatches->First()->Link());
                 } elseif ($ExactCount > 1 || $PossibleCount > 1) {
                     $ExactMatches->merge($PossibleMatches);

--- a/code/Intelligent404.php
+++ b/code/Intelligent404.php
@@ -72,7 +72,7 @@ class Intelligent404 extends Extension
                     return $this->RedirectToPage($ExactMatches->First()->Link());
                 } elseif ($ExactCount == 0 && $PossibleCount == 1 && $redirectOnSingleMatch) {
                     return $this->RedirectToPage($PossibleMatches->First()->Link());
-                } elseif ($ExactCount > 1 || $PossibleCount > 1) {
+                } elseif ($ExactCount > 1 || $PossibleCount > 1 || !$redirectOnSingleMatch) {
                     $ExactMatches->merge($PossibleMatches);
                     $content = $this->owner->customise(array(
                         'Pages' => $ExactMatches


### PR DESCRIPTION
Non BC-breaking change adding a config option to be able to disable single match redirects.

This feature will allow us to use this module to provide page suggestions and use legacy redirect module where the intelligent 404 was kicking in too early (making single matches redirect before hitting the redirect rules).
